### PR TITLE
Fix anchor marker pen style argument

### DIFF
--- a/main.py
+++ b/main.py
@@ -781,7 +781,7 @@ class NodeItem(QGraphicsObject):
         for pos in self.anchor_positions():
             marker = QGraphicsEllipseItem(-3, -3, 6, 6, self)
             marker.setBrush(QBrush(QColor("#00AEEF")))
-            marker.setPen(Qt.NoPen)
+            marker.setPen(QPen(Qt.NoPen))
             marker.setZValue(1000)
             marker.setPos(pos)
             self._anchor_markers.append(marker)


### PR DESCRIPTION
## Summary
- Fix QGraphicsEllipseItem pen style by wrapping `Qt.NoPen` in `QPen` when showing anchor points

## Testing
- `python main.py` *(fails: ModuleNotFoundError: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_68a1f3d3ef10832dba761e01a1943ce4