### PR TITLE
Fix PDF export and map printing

### DIFF
--- a/main.py
+++ b/main.py
@@ -195,11 +195,13 @@ class CXLDocument:
             ns_uri = self.root.tag[1:].split("}")[0]
             self.ns = {"c": ns_uri}
         # Find map
-        map_elem = self.root.find("c:map", self.ns) or self.root.find("map")
+        map_elem = self.root.find("c:map", self.ns)
+        if map_elem is None:
+            map_elem = self.root.find("map")
         if map_elem is None:
             raise ValueError("Il file non contiene un elemento <map>.")
         # Determine format
-        self.appearance_mode = bool(map_elem.find("c:concept-appearance-list", self.ns))
+        self.appearance_mode = map_elem.find("c:concept-appearance-list", self.ns) is not None
         # Parse concepts and linking phrases
         if self.appearance_mode:
             # Concept list
@@ -1568,13 +1570,17 @@ class ConceptMapEditor(QMainWindow):
         printer = QPrinter(QPrinter.HighResolution)
         printer.setOutputFormat(QPrinter.PdfFormat)
         printer.setOutputFileName(filepath)
-        self.view.render(printer)
+        painter = QPainter(printer)
+        self.view.render(painter)
+        painter.end()
 
     def print_map(self) -> None:
         printer = QPrinter(QPrinter.HighResolution)
         dialog = QPrintDialog(printer, self)
         if dialog.exec_() == QDialog.Accepted:
-            self.view.render(printer)
+            painter = QPainter(printer)
+            self.view.render(painter)
+            painter.end()
 
     def edit_style(self) -> None:
         items = self.scene.selectedItems()


### PR DESCRIPTION
## Summary
- avoid deprecated truthiness check when parsing map
- use QPainter for PDF export and printing

## Testing
- `python -m py_compile main.py`
- `python main.py` *(fails: No module named 'PyQt5')*
- `pip install PyQt5` *(fails: Could not find a version that satisfies the requirement PyQt5)*

------
https://chatgpt.com/codex/tasks/task_e_68a25066ea4c832d87e007a1023e2589