### PR TITLE
Add application icon

### DIFF
--- a/main.py
+++ b/main.py
@@ -82,6 +82,7 @@ from PyQt5.QtGui import (
     QTextCursor,
     QKeySequence,
     QPixmap,
+    QIcon,
 )
 from PyQt5.QtWidgets import (
     QApplication,
@@ -1649,6 +1650,7 @@ class ConceptMapEditor(QMainWindow):
     def __init__(self) -> None:
         super().__init__()
         self.setWindowTitle("CXL Concept Map Editor (PyQt)")
+        self.setWindowIcon(QIcon(os.path.join(os.path.dirname(__file__), "antmapicon.png")))
         self.resize(1024, 768)
         # Data model
         self.document = CXLDocument()
@@ -2499,6 +2501,7 @@ def main() -> None:
     QApplication.setAttribute(Qt.AA_EnableHighDpiScaling, True)
     QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps, True)
     app = QApplication(sys.argv)
+    app.setWindowIcon(QIcon(os.path.join(os.path.dirname(__file__), "antmapicon.png")))
     app.setStyle("Fusion")
     palette = QPalette()
     palette.setColor(QPalette.Window, QColor(53, 53, 53))


### PR DESCRIPTION
## Summary
- Set a custom window icon for the concept map editor using `antmapicon.png`.
- Apply the application icon to all windows via the `main` startup routine.

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5ac8a5690832d9ce8fa5279f48d45