### PR TITLE
Handle trackpad scroll vs mouse wheel

### DIFF
--- a/main.py
+++ b/main.py
@@ -1465,14 +1465,16 @@ class GraphicsView(QGraphicsView):
         super().mouseReleaseEvent(event)
 
     def wheelEvent(self, event):
-        # Trackpad scroll (pixelDelta) pans; mouse wheel (angleDelta) zooms
-        if event.pixelDelta().manhattanLength() > 0:
-            delta = event.pixelDelta()
-            self.horizontalScrollBar().setValue(self.horizontalScrollBar().value() - delta.x())
-            self.verticalScrollBar().setValue(self.verticalScrollBar().value() - delta.y())
-        else:
+        """Pan with trackpad scroll and zoom with a real mouse wheel."""
+        if event.source() == Qt.MouseEventNotSynthesized:
             factor = 1.2 if event.angleDelta().y() > 0 else 1 / 1.2
             self.scale(factor, factor)
+        else:
+            delta = event.pixelDelta()
+            if delta.manhattanLength() == 0:
+                delta = event.angleDelta()
+            self.horizontalScrollBar().setValue(self.horizontalScrollBar().value() - delta.x())
+            self.verticalScrollBar().setValue(self.verticalScrollBar().value() - delta.y())
 
     def event(self, event):
         if event.type() == QEvent.Gesture:


### PR DESCRIPTION
## Summary
- Distinguish trackpad vs mouse wheel events in GraphicsView
- Trackpad scroll now pans reliably even when angleDelta is used
- Mouse wheel events continue to zoom the view

## Testing
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5b1bdcb24832d94fc0fe00db6cf95