### PR TITLE
Ensure toolbar title text remains black

### DIFF
--- a/main.py
+++ b/main.py
@@ -1832,9 +1832,7 @@ class ConceptMapEditor(QMainWindow):
             "QToolBar { background: #f9f9f9; border: none; border-bottom: 1px solid #ccc; }"
         )
         title_label = QLabel("AntMap")
-        title_label.setStyleSheet("color: black; font-weight: bold;")
-
-        title_label.setStyleSheet("font-weight: bold; padding: 0 8px;")
+        title_label.setStyleSheet("color: black; font-weight: bold; padding: 0 8px;")
         toolbar.addWidget(title_label)
         toolbar.addSeparator()
         toolbar.addAction(self.undo_act)


### PR DESCRIPTION
## Summary
- keep toolbar title label color set to black and avoid overwriting with subsequent styling

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5bf89c680832da1616a72972e03fa